### PR TITLE
Changed screen escape key to C-o. Added s as dependency.

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -35,12 +35,13 @@
 ;; the Julia REPL facilities for interactive features, such readline,
 ;; help, debugging.
 
-;; Package-Requires: ((emacs "25") (dash "2.13.0"))
+;; Package-Requires: ((emacs "25") (dash "2.13.0") (s "1.11.0"))
 
 ;;; Code:
 
 (require 'dash)
 (require 'term)
+(require 's)
 
 (advice-add 'term-handle-ansi-escape :before
             #'(lambda (proc char)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -42,24 +42,15 @@
 (require 'dash)
 (require 'term)
 
-(when (and (= emacs-major-version 25) (< emacs-minor-version 2))
-  ;; (defun julia-repl-fix-ansi-escapes (proc char)
-  ;;   "Handle additional ansi escapes."
-  ;;   (cond
-  ;;    ;; \E[nG - Cursor Horizontal Absolute, e.g. move cursor to column n
-  ;;    ((eq char ?G)
-  ;;     (let ((col (min term-width (max 0 term-terminal-parameter))))
-  ;;       (term-move-columns (- col (term-current-column)))))
-  ;;    (t)))
-  (advice-add 'term-handle-ansi-escape :before
-              #'(lambda (proc char)
-                  "Handle additional ansi escapes."
-                  (cond
-                   ;; \E[nG - CHA
-                   ((eq char ?G)
-                    (let ((col (min term-width (max 0 term-terminal-parameter))))
-                      (term-move-columns (- col (term-current-column)))))
-                   (t)))))
+(advice-add 'term-handle-ansi-escape :before
+            #'(lambda (proc char)
+                "Handle additional ansi escapes."
+                (cond
+                 ;; \E[nG - CHA
+                 ((eq char ?G)
+                  (let ((col (min term-width (max 0 term-terminal-parameter))))
+                    (term-move-columns (- col (term-current-column)))))
+                 (t))))
 
 (defcustom julia-repl-buffer-name "julia"
   "Buffer name for the Julia REPL. Will be surrounded by *'s"


### PR DESCRIPTION
C-a is a very useful shortcut in the REPL, while C-o seems less useful. It might be wiser to leave it to users to set this in .screenrc, as this will override anything set there. Resolves #4 #3 . 