### PR TITLE
Autoload the julia-repl command

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -102,6 +102,7 @@ Buffer is not raised."
         (julia-repl--start-and-setup))
     (julia-repl--start-and-setup)))
 
+;;;###autoload
 (defun julia-repl ()
   "Raise the Julia REPL term buffer, creating one if it does not exist.
 This should be the standard entry point."


### PR DESCRIPTION
Since julia-repl can be used as an entry point, it's useful to
autoload. Otherwise, users cannot try this package until they've
enabled julia-repl-mode.

Since the README mentions `julia-repl` as an entry point, I think
this makes sense. It's also a nice way to get started with the
package.