### PR TITLE
Workaround Org Src buffers incorrectly setting buffer-file-name

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -559,7 +559,8 @@ When called with a prefix argument, activate the home project."
     (,(kbd "C-c C-v")    . julia-repl-prompt-set-executable-key)
     (,(kbd "C-c C-p")    . julia-repl-cd)
     (,(kbd "C-c C-a")    . julia-repl-activate-parent))
-  (when-let ((filename (buffer-file-name)))
+  (when-let ((filename (buffer-file-name))
+             (identity buffer-file-truename))
     (setq-local default-directory (file-name-directory filename))))
 
 (provide 'julia-repl)


### PR DESCRIPTION
Commit 25f99522ad in org-mode removes this bug from Org Src buffers. This hacky
workaround is only necessary until a version of org-mode is released including
that commit.

Fixes #41

I'm still a bit of an elisp novice, so if the `identity` function isn't the proper way of handling this situation where I just want to check that `buffer-file-truename` is not `nil`, please let me know.