### PR TITLE
Switch to main REPL before sending code

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -438,6 +438,7 @@ Unless NO-BRACKETED-PASTE, bracketed paste control sequences are used."
   (let ((inferior-buffer (julia-repl-inferior-buffer)))
     (display-buffer inferior-buffer)
     (with-current-buffer inferior-buffer
+      (term-send-raw-string "\b")       ; send backspace to exit pkg> or shell>
       (unless no-bracketed-paste        ; bracketed paste start
         (term-send-raw-string "\e[200~"))
       (term-send-raw-string (string-trim string))


### PR DESCRIPTION
I sometimes accidentally send code to the pkg> repl. This change sends a backspace before sending code.

If there were use-cases for sending code to pkg> or shell> repls, I wasn't aware of them.