### PR TITLE
add commands to set JULIA_EDITOR, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Note some keybindings for `term`:
 
 See the help of `term` for more.
 
+## Using the @edit macro
+
+The `@edit` macro can be called with `C-c C-e` when the `julia-repl-mode` minor mode is enabled. The behavior depends on the value of the `JULIA_EDITOR` envoronment variable in the Julia session. The command `julia-repl-set-julia-editor` is provided to conveniently control this from emacs.
+
+To use "emacsclient" as a default in each Julia REPL, call `julia-repl-use-emacsclient`:
+
+```elisp
+(add-hook 'julia-repl-hook #'julia-repl-use-emacsclient)
+```
+
 ## Limitations
 
 See the [issues](https://github.com/tpapp/julia-repl/issues).

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -544,6 +544,16 @@ When called with a prefix argument, activate the home project."
                      (expand-file-name (file-name-directory projectfile)) "\")")))
         (message "could not find project file")))))
 
+(defun julia-repl-set-julia-editor (editor)
+  "Set the JULIA_EDITOR environment variable."
+  (interactive)
+  (julia-repl--send-string (format "ENV[\"JULIA_EDITOR\"] = \"%s\";" editor)))
+
+(defun julia-repl-use-emacsclient ()
+  "Use emacsclient as the JULIA_EDITOR."
+  (interactive)
+  (julia-repl--send-string "ENV[\"JULIA_EDITOR\"] = \"emacsclient\";"))
+
 ;;;###autoload
 (define-minor-mode julia-repl-mode
   "Minor mode for interacting with a Julia REPL running inside a term."


### PR DESCRIPTION
This adds interactive functions that set the `JULIA_EDITOR` environment variable for a REPL buffer. Since "emacsclient" is a sensible default, I also thought it would be nice to make that easy to use with`julia-repl-hook`:

```elisp
(add-hook 'julia-repl-hook #'julia-repl-use-emacsclient)
```

Updates the README as well.

If you merge this, then I think it would resolve #22 and #23.