### PR TITLE
have julia-repl-cd also set default-directory

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -520,8 +520,10 @@ this with a prefix argument ARG."
 (defun julia-repl-cd ()
   "Change directory to the directory of the current buffer (if applicable)."
   (interactive)
-  (if-let ((filename (buffer-file-name)))
-      (julia-repl--send-string (concat "cd(\"" (file-name-directory filename) "\")"))
+  (if-let ((directory (file-name-directory (buffer-file-name))))
+      (progn
+	(julia-repl--send-string (concat "cd(\"" directory "\")"))
+	(with-current-buffer (julia-repl-inferior-buffer) (cd directory)))
     (warn "buffer not associated with a file")))
 
 (defun julia-repl-activate-parent (arg)


### PR DESCRIPTION
I found myself getting a little confused about where I was (so to speak) when I realized that `C-c C-p` (`julia-repl-cd`) was updating the "working directory" for the julia process, but not for emacs. For example, `C-c C-p` changes the result of `julia> pwd()` in julia, but it does not change the result of `M-x pwd`. Maybe this is just a personal preference, but I find things much easier when emacs moves the buffer's location to match the julia process.