### PR TITLE
Send region via include

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you want to use a Julia executable other than `julia` in your path, see [belo
 | key           | action                                                      |
 |---------------|-------------------------------------------------------------|
 | `C-c C-c`     | send region (when applicable) or line to REPL               |
+| `C-c C-f`     | send region to REPL (creating a temp file and using include)|
 | `C-c C-b`     | send whole buffer to REPL (using include)                   |
 | `C-u C-c C-b` | send whole buffer to REPL (directly)                        |
 | `C-c C-z`     | raise the REPL or create a new one                          |
@@ -39,6 +40,8 @@ If you want to use a Julia executable other than `julia` in your path, see [belo
 | `C-u C-c C-a` | activate home project                                       |
 
 All actions that send something to the REPL terminate with a **newline**, triggering evaluation. If you want to avoid sending a newline (eg maybe because you want to edit an expression), use prefix arguments (`C--` or `C-u`, currently both have the same effect). This of course does not apply to `C-c C-b`.
+
+Command `C-c C-f` automatically creates a file with name `(buffer-name).part.jl` containing the content of the region (and a commented header line referencing the original buffer name and line numbers in that buffer), and sends its content to the REPL by an `include()` command.
 
 All commands send code using [bracketed paste](https://cirw.in/blog/bracketed-paste). When Julia is waiting for input, control characters like `^[[200~` may show up in your buffer, this is innocuous. If you input takes a long time to evaluate, you can step through it line-by-line with `C-RET`.
 

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -81,6 +81,8 @@ Note that this affects all buffers using the ‘ansi-term’ map."
 ;; global variables
 ;;
 
+(defvar julia-repl-tmp-file-name-append ".part.jl")
+
 (defvar julia-repl--compilation-regexp-alist
   '(;; matches "while loading /tmp/Foo.jl, in expression starting on line 2"
     (julia-load-error . ("while loading \\([^ ><()\t\n,'\";:]+\\), in expression starting on line \\([0-9]+\\)" 1 2))
@@ -411,6 +413,40 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
              (propertize (symbol-name key) 'face 'font-lock-constant-face))))
 
 ;;
+;; send part of buffer to temporary file
+;;
+
+(defun julia-repl-tmp-file-name ()
+  "Return the name of the temporary file associated with a buffer."
+  (interactive)
+  (concat (file-name-sans-extension (buffer-name)) julia-repl-tmp-file-name-append))
+
+(defun julia-repl--send-region-to-tmp-file (&optional start end)
+  "Send active region (default), or region limited by START and END, to temporary file associated with a buffer, and in that file add a commented line showing the line numbers in the original buffer."
+  (let ((p1 start) (p2 end))
+    (if (use-region-p)
+	(progn
+	  (setq p1 (region-beginning))
+	  (setq p2 (region-end))
+	  (deactivate-mark)))
+    (if (and p1 p2)
+	(let ((fname (julia-repl-tmp-file-name)))
+	  (progn
+	    (write-region (concat (julia-repl--region-info p1 p2) "\n") nil fname)
+	    (write-region p1 p2 fname t)
+	    (and p1 p2)))))) ;; return t if it did something
+
+(defun julia-repl--region-info (&optional start end)
+  "Return a string containing a Julia comment with the buffer name and line numbers of the active region (default) or the region limited by START and END. Returns NIL if no region is active and no arguments are passed."
+  (let ((p1 start) (p2 end))
+    (if (use-region-p)
+	(progn
+	  (setq p1 (region-beginning))
+	  (setq p2 (region-end))))
+    (if (and p1 p2)
+	(format "# code from %s, lines %d:%d" (buffer-name) (line-number-at-pos p1 t) (line-number-at-pos p2 t)))))
+  
+;;
 ;; high-level functions
 ;;
 
@@ -520,6 +556,17 @@ this with a prefix argument ARG."
          (concat "include(\"" file "\")")
        (buffer-substring-no-properties (point-min) (point-max))))))
 
+(defun julia-repl-send-region-through-tmp-file (&optional start end)
+  "Send the active region, or optionnally the region ranging from START to END, to the Julia REPL by creating (erasing if needed) a temporary file associated with the current buffer."
+  (interactive)
+  (let ((msg (julia-repl--region-info start end)))
+    (if msg
+	(progn
+	  (julia-repl--send-region-to-tmp-file start end)
+	  (julia-repl--send-string
+	   (concat "include(\"" (julia-repl-tmp-file-name) "\") " msg)))
+      (message "No region to work with!"))))
+
 (defun julia-repl-doc ()
   "Documentation for symbol at point."
   (interactive)
@@ -570,6 +617,7 @@ When called with a prefix argument, activate the home project."
   nil ">"
   `((,(kbd "C-c C-c")    . julia-repl-send-region-or-line)
     (,(kbd "C-c C-b")    . julia-repl-send-buffer)
+    (,(kbd "C-c C-f")    . julia-repl-send-region-through-tmp-file)
     (,(kbd "C-c C-z")    . julia-repl)
     (,(kbd "<C-return>") . julia-repl-send-line)
     (,(kbd "C-c C-e")    . julia-repl-edit)


### PR DESCRIPTION
This is an attempt at solving #18. I am new to elisp so I hope it is not too badly written; but it works. I made the function `julia-repl-send-region-through-tmp-file` with two optional arguments with region `start` and `end`, so it can be used programmatically if needed.

Let me know what you think. (again the code might probably be simplified, I am not used to elisp).