### PR TITLE
Make it easier to use Revise.jl with julia-repl.el via include customization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to use a Julia executable other than `julia` in your path, see [belo
 |---------------|-------------------------------------------------------------|
 | `C-c C-c`     | send region (when applicable) or line to REPL               |
 | `C-c C-b`     | send whole buffer to REPL (using include)                   |
-| `C-c C-d`     | send whole buffer to REPL (using Revise.includet)           |
+| `C-c C-t`     | send whole buffer to REPL (using Revise.includet)           |
 | `C-u C-c C-b` | send whole buffer to REPL (directly)                        |
 | `C-c C-z`     | raise the REPL or create a new one                          |
 | `C-RET`       | send line to REPL (without bracketed paste)                 |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you want to use a Julia executable other than `julia` in your path, see [belo
 |---------------|-------------------------------------------------------------|
 | `C-c C-c`     | send region (when applicable) or line to REPL               |
 | `C-c C-b`     | send whole buffer to REPL (using include)                   |
+| `C-c C-d`     | send whole buffer to REPL (using Revise.includet)           |
 | `C-u C-c C-b` | send whole buffer to REPL (directly)                        |
 | `C-c C-z`     | raise the REPL or create a new one                          |
 | `C-RET`       | send line to REPL (without bracketed paste)                 |

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -517,8 +517,22 @@ this with a prefix argument ARG."
         (setq file nil)))
     (julia-repl--send-string
      (if file
-         (concat "include(\"" file "\")")
+         (concat "include(\"" file "\");")
        (buffer-substring-no-properties (point-min) (point-max))))))
+
+
+(defun julia-repl-includet-buffer (arg)
+  "Attempts to include a buffer, ARG, via Revise's includet.  If a buffer does not correspond to a file, the function does nothing.  If a buffer corresponds to a file and is not saved, the function prompts the user to save.  If the user refuses to save the file, nothing happen."
+  (interactive "P")
+  (let* ((file (and (not arg) buffer-file-name)))
+    (when (and file (buffer-modified-p))
+      (if (y-or-n-p "Buffer modified, save? ")
+          (save-buffer)
+        (setq file nil)))
+    (if file
+	(julia-repl--send-string (concat "Revise.includet(\"" file "\");"))
+      ())))
+
 
 (defun julia-repl-doc ()
   "Documentation for symbol at point."
@@ -570,6 +584,7 @@ When called with a prefix argument, activate the home project."
   nil ">"
   `((,(kbd "C-c C-c")    . julia-repl-send-region-or-line)
     (,(kbd "C-c C-b")    . julia-repl-send-buffer)
+    (,(kbd "C-c C-d")    . julia-repl-includet-buffer)
     (,(kbd "C-c C-z")    . julia-repl)
     (,(kbd "<C-return>") . julia-repl-send-line)
     (,(kbd "C-c C-e")    . julia-repl-edit)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -584,7 +584,7 @@ When called with a prefix argument, activate the home project."
   nil ">"
   `((,(kbd "C-c C-c")    . julia-repl-send-region-or-line)
     (,(kbd "C-c C-b")    . julia-repl-send-buffer)
-    (,(kbd "C-c C-d")    . julia-repl-includet-buffer)
+    (,(kbd "C-c C-t")    . julia-repl-includet-buffer)
     (,(kbd "C-c C-z")    . julia-repl)
     (,(kbd "<C-return>") . julia-repl-send-line)
     (,(kbd "C-c C-e")    . julia-repl-edit)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -517,12 +517,12 @@ this with a prefix argument ARG."
         (setq file nil)))
     (julia-repl--send-string
      (if file
-         (concat "include(\"" file "\");")
+         (concat "include(\"" file "\")")
        (buffer-substring-no-properties (point-min) (point-max))))))
 
 
-(defun julia-repl-includet-buffer (arg)
-  "Attempts to include a buffer, ARG, via Revise's includet.  If a buffer does not correspond to a file, the function does nothing.  If a buffer corresponds to a file and is not saved, the function prompts the user to save.  If the user refuses to save the file, nothing happen."
+(defun julia-repl-includet-buffer ()
+  "Attempts to include a buffer via Revise's includet.  If a buffer does not correspond to a file, the function does nothing.  If a buffer corresponds to a file and is not saved, the function prompts the user to save.  If the user refuses to save the file, nothing happen."
   (interactive)
   (let* ((file buffer-file-name))
     (when (and file (buffer-modified-p))

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -524,7 +524,7 @@ this with a prefix argument ARG."
 (defun julia-repl-includet-buffer (arg)
   "Attempts to include a buffer, ARG, via Revise's includet.  If a buffer does not correspond to a file, the function does nothing.  If a buffer corresponds to a file and is not saved, the function prompts the user to save.  If the user refuses to save the file, nothing happen."
   (interactive "P")
-  (let* ((file (and (not arg) buffer-file-name)))
+  (let* ((file buffer-file-name))
     (when (and file (buffer-modified-p))
       (if (y-or-n-p "Buffer modified, save? ")
           (save-buffer)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -523,7 +523,7 @@ this with a prefix argument ARG."
 
 (defun julia-repl-includet-buffer (arg)
   "Attempts to include a buffer, ARG, via Revise's includet.  If a buffer does not correspond to a file, the function does nothing.  If a buffer corresponds to a file and is not saved, the function prompts the user to save.  If the user refuses to save the file, nothing happen."
-  (interactive "P")
+  (interactive)
   (let* ((file buffer-file-name))
     (when (and file (buffer-modified-p))
       (if (y-or-n-p "Buffer modified, save? ")

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -531,7 +531,7 @@ this with a prefix argument ARG."
         (setq file nil)))
     (if file
 	(julia-repl--send-string (concat "Revise.includet(\"" file "\");"))
-      ())))
+      (message "buffer has no file or not saved"))))
 
 
 (defun julia-repl-doc ()


### PR DESCRIPTION
I like to use Revise.jl as many others do. Revise.jl won't track code added via include, but will for includet; thus, a customization (julia-repl-include) is added to configure which command C-c C-b uses. To make the default include available at all times, C-c C-d is used. julia-repl-send-buffer accommodates both via optional arguments.