### PR TITLE
Add option to save buffer on send

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -77,6 +77,11 @@ Note that this affects all buffers using the ‘ansi-term’ map."
   :type 'boolean
   :group 'julia-repl)
 
+(defcustom julia-repl-save-buffer-on-send nil
+  "When non-nil, save buffer without prompting on send."
+  :type 'boolean
+  :group 'julia-repl)
+
 ;;
 ;; global variables
 ;;
@@ -512,7 +517,7 @@ this with a prefix argument ARG."
   (interactive "P")
   (let* ((file (and (not arg) buffer-file-name)))
     (when (and file (buffer-modified-p))
-      (if (y-or-n-p "Buffer modified, save? ")
+      (if (or julia-repl-save-buffer-on-send (y-or-n-p "Buffer modified, save? "))
           (save-buffer)
         (setq file nil)))
     (julia-repl--send-string

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -537,7 +537,7 @@ If a buffer corresponds to a file and is not saved, the function prompts the use
     (if file
         (progn
           (when (buffer-modified-p)
-            (if (y-or-n-p "Buffer modified, save? ")
+            (if (or julia-repl-save-buffer-on-send (y-or-n-p "Buffer modified, save? "))
                 (save-buffer)
               (unless (file-exists-p file)
                 (message "need to save the file first"))))


### PR DESCRIPTION
ESS does this without asking, which I find more convenient (when I want to send a buffer, I want to save it first). I think it's the most appropriate behavior but I appreciate others might find that dangerous, so I've left disabled by default; if you feel it's OK I can toggle it on.