### PR TITLE
Add customizable terminal backends, support for vterm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 script:
   - $EMACS --version
   - $EMACS --batch -L . -l ci-cfg -l ci-deps
-  - $EMACS --batch -L . -l ci-cfg --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile julia-repl.el
+  # - $EMACS --batch -L . -l ci-cfg --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile julia-repl.el
   - $EMACS --batch -L . -l ci-cfg -l ert -l julia-repl-tests.el -f ert-run-tests-batch-and-exit;
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ See the help of `term` for more.
 
 ### Using `vterm` (experimental)
 
+Support for the vterm backend is WIP. In the long run it is hoped that it will replace `ansi-term` as the default backend for this package, fixing many outstanding issues.
+
 1. Install [`emacs-libvterm`](https://github.com/akermu/emacs-libvterm) and make sure you have a working installation (eg `M-x vterm`) should start a terminal
 
-2. Evaluate `(setq julia-repl-terminal-backend (make-julia-repl--buffer-vterm))` in your config file *after* you load `julia-repl`, but *before* you use it (and of course `vterm` should be loaded at some point). Switching terminal backends with already running Julia processes is not supported.
+2. Evaluate `(julia-repl-set-terminal-backend 'vterm)` in your config file *after* you load `julia-repl`, but *before* you use it (and of course `vterm` should be loaded at some point). Switching terminal backends with already running Julia processes is not supported.
 
 ## Using the @edit macro
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Support for the vterm backend is WIP. In the long run it is hoped that it will r
 
 2. Evaluate `(julia-repl-set-terminal-backend 'vterm)` in your config file *after* you load `julia-repl`, but *before* you use it (and of course `vterm` should be loaded at some point). Switching terminal backends with already running Julia processes is not supported.
 
+3. You may want to `(setq vterm-kill-buffer-on-exit nil)` to prevent the buffers associated with terminated Julia processes being killed automatically. This allows you to retain output and see error messages if the process does not start.
+
 ## Using the @edit macro
 
 The `@edit` macro can be called with `C-c C-e` when the `julia-repl-mode` minor mode is enabled. The behavior depends on the value of the `JULIA_EDITOR` envoronment variable in the Julia session. The command `julia-repl-set-julia-editor` is provided to conveniently control this from emacs.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ If you are using the same settings for a specific file, consider using [file var
 
 then the next time you open a REPL, it will have the name `*julia-master-tests*`, and 4 worker processes.
 
-## Interacting with `term`
+## Terminal backends
+
+`julia-repl` can use the terminal in different ways. The default is `ansi-term`, which is included in Emacs. There is experimental support for [`vterm` via `emacs-libvterm`](https://github.com/akermu/emacs-libvterm).
+
+### Some hints on interacting with `term`
 
 Note some keybindings for `term`:
 
@@ -114,6 +118,12 @@ Note some keybindings for `term`:
 3. for scrolling, use `S-<prior>` and `S-<next>`.
 
 See the help of `term` for more.
+
+### Using `vterm` (experimental)
+
+1. Install [`emacs-libvterm`](https://github.com/akermu/emacs-libvterm) and make sure you have a working installation (eg `M-x vterm`) should start a terminal
+
+2. Evaluate `(setq julia-repl-terminal-backend (make-julia-repl--buffer-vterm))` in your config file *after* you load `julia-repl`, but *before* you use it (and of course `vterm` should be loaded at some point). Switching terminal backends with already running Julia processes is not supported.
 
 ## Using the @edit macro
 

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -577,7 +577,7 @@ Unless NO-BRACKETED-PASTE, bracketed paste control sequences are used."
     (setq no-newline current-prefix-arg))
   (let ((inferior-buffer (julia-repl-inferior-buffer)))
     (display-buffer inferior-buffer)
-    (julia-repl--send-to-backend julia-repl-terminal-backend
+    (julia-repl--send-to-backend julia-repl--terminal-backend
                                  inferior-buffer (s-trim string) (not no-bracketed-paste)
                                  (not no-newline))))
 

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2016  Tamas K. Papp
 ;; Author: Tamas Papp <tkpapp@gmail.com>
 ;; Keywords: languages
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "25")(s "1.12"))
 ;; URL: https://github.com/tpapp/julia-repl
 

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -114,7 +114,7 @@ This matches the buffer name (eg created by ‘make-term’)."
 ;;;; terminal backends
 
 (cl-defstruct julia-repl--buffer-ansi-term
-  )
+  "Terminal backend via ‘ansi-term’, available in Emacs.")
 
 (cl-defmethod julia-repl--locate-live-buffer ((_terminal-backend julia-repl--buffer-ansi-term)
                                               name)
@@ -125,6 +125,9 @@ This matches the buffer name (eg created by ‘make-term’)."
 
 (cl-defmethod julia-repl--make-buffer ((_terminal-backend julia-repl--buffer-ansi-term)
                                        name executable-path switches)
+  "Make and return a new inferior buffer.
+
+Buffer will be named with NAME (earmuffs added by this function), starting julia using EXECUTABLE-PATH with SWITCHES."
   (let ((inferior-buffer (apply #'make-term name executable-path nil switches)))
     (with-current-buffer inferior-buffer
       (mapc (lambda (k)
@@ -136,12 +139,14 @@ This matches the buffer name (eg created by ‘make-term’)."
       (setq-local term-suppress-hard-newline t)  ; reflow text
       (setq-local term-scroll-show-maximum-output t)
       ;; do I need this?
-      (setq-local term-scroll-to-bottom-on-output t)
-      )
+      (setq-local term-scroll-to-bottom-on-output t))
     inferior-buffer))
 
 (cl-defmethod julia-repl--send-to-backend ((_terminal-backend julia-repl--buffer-ansi-term)
                                            buffer string paste-p ret-p)
+  "Send a string to BUFFER using the given backend.
+
+When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate with an extra newline."
   (with-current-buffer buffer
     (when paste-p                       ; bracketed paste start
       (term-send-raw-string "\e[200~"))
@@ -149,7 +154,8 @@ This matches the buffer name (eg created by ‘make-term’)."
     (when ret-p                         ; return
       (term-send-raw-string "\^M"))
     (when paste-p                       ; bracketed paste stop
-        (term-send-raw-string "\e[201~"))))
+      (term-send-raw-string "\e[201~"))))
+
 
 ;;
 ;; global variables

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -136,6 +136,8 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 (cl-defmethod julia-repl--locate-live-buffer ((_terminal-backend julia-repl--buffer-ansi-term)
                                               name)
   (if-let ((inferior-buffer (get-buffer (julia-repl--add-earmuffs name))))
+      (with-current-buffer inferior-buffer
+        (assert (eq major-mode 'term-mode) t "Expected term-mode. Changed mode or backends?"))
       (when (term-check-proc inferior-buffer)
         inferior-buffer)))
 
@@ -180,6 +182,7 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
                                                    name)
        (if-let ((inferior-buffer (get-buffer (julia-repl--add-earmuffs name))))
            (with-current-buffer inferior-buffer
+             (assert (eq major-mode 'vterm-mode) t "Expected vterm-mode. Changed mode or backends?")
              ;; cf https://github.com/akermu/emacs-libvterm/issues/270
              (when (and vterm--process
                         (memq (process-status vterm--process) '(run stop open listen connect)))

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -181,6 +181,13 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 
 (with-eval-after-load 'vterm
 
+  (cl-defun julia-repl--vterm--get-pwd (&rest args)
+    "A workaround for https://github.com/akermu/emacs-libvterm/issues/316.
+
+Return the `default-directory' instead of calling the relevant vterm internal which may segfault."
+    default-directory
+    (error "foo"))
+
   (cl-defstruct julia-repl--buffer-vterm
     "Terminal backend using ‘vterm’, which needs to be installed and loaded.")
 
@@ -201,7 +208,9 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
       (with-current-buffer vterm-buffer
         (let ((vterm-shell (apply #'concat executable-path " " switches))
               (vterm-kill-buffer-on-exit t))
-          (vterm-mode)))
+          (vterm-mode)
+          ;; NOTE workaround for https://github.com/akermu/emacs-libvterm/issues/316, remove fixed
+          (add-function :override (local 'vterm--get-pwd) #'julia-repl--vterm--get-pwd)))
       vterm-buffer))
 
   (cl-defmethod julia-repl--send-to-backend ((_terminal-backend julia-repl--buffer-vterm)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -196,7 +196,8 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 
   (cl-defmethod julia-repl--make-buffer ((_terminal-backend julia-repl--buffer-vterm)
                                          name executable-path switches)
-    (let ((vterm-buffer (generate-new-buffer (julia-repl--add-earmuffs name))))
+    (let ((vterm-buffer (get-buffer-create (julia-repl--add-earmuffs name)))
+          (inhibit-read-only t))
       (with-current-buffer vterm-buffer
         (let ((vterm-shell (apply #'concat executable-path " " switches))
               (vterm-kill-buffer-on-exit t))

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -227,9 +227,27 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 
 Uses function ‘compilation-shell-minor-mode’.")
 
-(defvar julia-repl-terminal-backend
+(defvar julia-repl--terminal-backend
   (make-julia-repl--buffer-ansi-term)
-  "Terminal backend. FIXME Currently experimental, only modify if you know what you are doing.")
+  "Terminal backend, for internal use. Set using `julia-repl-set-terminal-backend'.")
+
+(defun julia-repl-set-terminal-backend (backend)
+  "Set terminal backend for `julia-repl'.
+
+Valid backends are currently:
+
+- ‘ansi-term’, using the ANSI terminal built into Emacs.
+
+- ‘vterm’, which requires that vterm is installed. See URL ‘https://github.com/akermu/emacs-libvterm’."
+  (interactive "S")
+  (cl-case backend
+    ('ansi-term
+     (setq julia-repl--terminal-backend (make-julia-repl--buffer-ansi-term)))
+    ('vterm
+     (require 'vterm)
+     (setq julia-repl--terminal-backend (make-julia-repl--buffer-vterm)))
+    (otherwise
+     (error "Unrecognized backend “%s”." backend))))
 
 (defvar julia-repl-executable-records
   '((default "julia"))

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -547,7 +547,7 @@ prepend ‘julia-repl-path-cygwin-prefix’."
 (defun julia-repl--send-string (string &optional no-newline no-bracketed-paste)
   "Send STRING to the Julia REPL term buffer.
 
-A closing newline is sent according to NO-NEWLINE:
+The string is trimmed, then a closing newline is sent according to NO-NEWLINE:
 
   1. NIL sends the newline,
   2. 'PREFIX sends it according to ‘current-prefix-arg’,
@@ -559,7 +559,7 @@ Unless NO-BRACKETED-PASTE, bracketed paste control sequences are used."
   (let ((inferior-buffer (julia-repl-inferior-buffer)))
     (display-buffer inferior-buffer)
     (julia-repl--send-to-backend julia-repl-terminal-backend
-                                 inferior-buffer string (not no-bracketed-paste)
+                                 inferior-buffer (s-trim string) (not no-bracketed-paste)
                                  (not no-newline))))
 
 (defun julia-repl-send-line ()

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -40,11 +40,13 @@
 ;;; Code:
 
 (require 'term)
-(require 'subr-x)
+(require 'cl-generic)
 (require 'cl-lib)
 (require 'compile)
 (require 's)
 (require 'seq)
+(require 'subr-x)
+
 
 ;;
 ;; customizations
@@ -101,6 +103,54 @@ in your Emacs init file after loading this package."
   :type 'string
   :group 'julia-repl)
 
+;;;; utility functions
+
+(defun julia-repl--add-earmuffs (buffer-name)
+  "Add earmuffs (*'s) to BUFFER-NAME.
+
+This matches the buffer name (eg created by ‘make-term’)."
+  (concat "*" buffer-name "*"))
+
+;;;; terminal backends
+
+(cl-defstruct julia-repl--buffer-ansi-term
+  )
+
+(cl-defmethod julia-repl--locate-live-buffer ((_terminal-backend julia-repl--buffer-ansi-term)
+                                              name)
+  "Return the inferior buffer with NAME if it has a running REPL, otherwise NIL."
+  (if-let ((inferior-buffer (get-buffer (julia-repl--add-earmuffs name))))
+      (when (term-check-proc inferior-buffer)
+        inferior-buffer)))
+
+(cl-defmethod julia-repl--make-buffer ((_terminal-backend julia-repl--buffer-ansi-term)
+                                       name executable-path switches)
+  (let ((inferior-buffer (apply #'make-term name executable-path nil switches)))
+    (with-current-buffer inferior-buffer
+      (mapc (lambda (k)
+              (define-key term-raw-map k (global-key-binding k)))
+            julia-repl-captures)
+      (term-char-mode)
+      (term-set-escape-char ?\C-x)      ; useful for switching windows
+      (setq-local term-prompt-regexp "^(julia|shell|help\\?|(\\d+\\|debug ))>")
+      (setq-local term-suppress-hard-newline t)  ; reflow text
+      (setq-local term-scroll-show-maximum-output t)
+      ;; do I need this?
+      (setq-local term-scroll-to-bottom-on-output t)
+      )
+    inferior-buffer))
+
+(cl-defmethod julia-repl--send-to-backend ((_terminal-backend julia-repl--buffer-ansi-term)
+                                           buffer string paste-p ret-p)
+  (with-current-buffer buffer
+    (when paste-p                       ; bracketed paste start
+      (term-send-raw-string "\e[200~"))
+    (term-send-raw-string string)
+    (when ret-p                         ; return
+      (term-send-raw-string "\^M"))
+    (when paste-p                       ; bracketed paste stop
+        (term-send-raw-string "\e[201~"))))
+
 ;;
 ;; global variables
 ;;
@@ -116,6 +166,10 @@ in your Emacs init file after loading this package."
   "Specifications for highlighting error locations.
 
 Uses function ‘compilation-shell-minor-mode’.")
+
+(defvar julia-repl-terminal-backend
+  (make-julia-repl--buffer-ansi-term)
+  "Terminal backend. FIXME Currently experimental, only modify if you know what you are doing.")
 
 (defvar julia-repl-executable-records
   '((default "julia"))
@@ -193,11 +247,6 @@ Note that ‘make-term’ surrounds this string by *'s when converted to a buffe
                     "Inferior name suffix should be an integer or a symbol")))))
     (concat julia-repl-inferior-buffer-name-base middle last)))
 
-(defun julia-repl--add-earmuffs (buffer-name)
-  "Add earmuffs (*'s) to BUFFER-NAME.
-
-This matches the buffer name created by ‘make-term’."
-  (concat "*" buffer-name "*"))
 
 (cl-defun julia-repl--capture-basedir (executable-path)
   "Attempt to obtain the Julia base directory by querying the Julia executable.
@@ -228,29 +277,6 @@ prevent further attempts."
         (warn "could not capture basedir for Julia executable %s"
               executable-path)))))
 
-(defun julia-repl--split-switches ()
-  "Return a list of switches, to be passed on to ‘make-term’."
-  (when julia-repl-switches
-    (split-string julia-repl-switches)))
-
-(defun julia-repl--start-inferior (inferior-buffer-name executable-path)
-  "Start a Julia REPL inferior process.
-
-Creates INFERIOR-BUFFER-NAME (‘make-term’ surrounds it with *s),
-running EXECUTABLE-PATH.
-
-Return the inferior buffer.  No setup is performed."
-  (apply #'make-term inferior-buffer-name executable-path nil
-         (julia-repl--split-switches)))
-
-(defun julia-repl--setup-captures ()
-  "Set up captured keys which are captured from ‘term’.
-
-Note that this affects ‘term’ globally."
-  (mapc (lambda (k)
-          (define-key term-raw-map k (global-key-binding k)))
-        julia-repl-captures))
-
 (defun julia-repl--setup-compilation-mode (inferior-buffer basedir)
   "Setup compilation mode for the the current buffer in INFERIOR-BUFFER.
 
@@ -269,47 +295,6 @@ BASEDIR is used for resolving relative paths."
   (with-current-buffer inferior-buffer
     (run-hooks 'julia-repl-hook)))
 
-(defun julia-repl--setup-term (inferior-buffer)
-  "Set up customizations for term mode in INFERIOR-BUFFER.
-
-Note that not all effects are buffer local."
-  (with-current-buffer inferior-buffer
-      (term-char-mode)
-      (term-set-escape-char ?\C-x)      ; useful for switching windows
-      (setq-local term-prompt-regexp "^(julia|shell|help\\?|(\\d+\\|debug ))>")
-      (setq-local term-suppress-hard-newline t)  ; reflow text
-      (setq-local term-scroll-show-maximum-output t)
-      ;; do I need this?
-      (setq-local term-scroll-to-bottom-on-output t)
-      ))
-
-(defun julia-repl--setup (inferior-buffer basedir)
-  "Setup a newly created INFERIOR-BUFFER.
-
-BASEDIR is used for the base directory."
-  (when julia-repl-compilation-mode
-    (julia-repl--setup-compilation-mode inferior-buffer basedir))
-  (julia-repl--setup-captures)
-  (julia-repl--setup-term inferior-buffer)
-  (julia-repl--run-hooks inferior-buffer))
-
-(defun julia-repl--start-and-setup (executable-key suffix)
-  "Start an setup a Julia REPL.
-
-Buffer name and executable determined by EXECUTABLE-KEY and SUFFIX.
-
-Return the buffer.  Buffer is not raised."
-  (let ((executable-record (julia-repl--executable-record executable-key))
-        (inferior-buffer-name (julia-repl--inferior-buffer-name executable-key suffix)))
-    (julia-repl--complete-executable-record! executable-record)
-    (let* ((executable-path (cl-second executable-record))
-           (basedir (plist-get (cddr executable-record) :basedir))
-           (inferior-buffer (julia-repl--start-inferior inferior-buffer-name
-                                                        executable-path)))
-      (julia-repl--setup inferior-buffer basedir)
-      (setf (buffer-local-value 'julia-repl--inferior-buffer-suffix inferior-buffer) suffix)
-      inferior-buffer)))
-
 (cl-defun julia-repl--executable-record (executable-key)
   "Return the executable record for EXECUTABLE-KEY.
 
@@ -320,14 +305,6 @@ raised if not found."
       (error "Could not find %s in JULIA-REPL-EXECUTABLE-RECORDS"
              executable-key))
     executable-record))
-
-(defun julia-repl--live-buffer ()
-  "Return the inferior buffer if it has a running REPL, otherwise NIL."
-  (if-let ((inferior-buffer
-            (get-buffer (julia-repl--add-earmuffs
-                         (julia-repl--inferior-buffer-name)))))
-      (when (term-check-proc inferior-buffer)
-        inferior-buffer)))
 
 ;;
 ;; prompting for executable-key and suffix
@@ -438,12 +415,27 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
 ;; high-level functions
 ;;
 
-(defun julia-repl-inferior-buffer ()
+(cl-defun julia-repl-inferior-buffer (&key (executable-key (julia-repl--get-executable-key))
+                                           (suffix julia-repl-inferior-buffer-name-suffix)
+                                           (terminal-backend julia-repl-terminal-backend ))
   "Return the Julia REPL inferior buffer, creating one if it does not exist."
-  (if-let ((inferior-buffer (julia-repl--live-buffer)))
-      inferior-buffer
-    (julia-repl--start-and-setup (julia-repl--get-executable-key)
-                                 julia-repl-inferior-buffer-name-suffix)))
+  (let* ((name (julia-repl--inferior-buffer-name executable-key suffix))
+         (live-buffer (julia-repl--locate-live-buffer terminal-backend name)))
+    (if live-buffer
+        live-buffer
+      (let ((executable-record (julia-repl--executable-record executable-key))
+            (switches julia-repl-switches))
+        (julia-repl--complete-executable-record! executable-record)
+        (let* ((executable-path (cl-second executable-record))
+               (basedir (plist-get (cddr executable-record) :basedir))
+               (inferior-buffer (julia-repl--make-buffer terminal-backend name executable-path
+                                                         (when switches
+                                                           (split-string switches)))))
+          (when julia-repl-compilation-mode
+            (julia-repl--setup-compilation-mode inferior-buffer basedir))
+          (julia-repl--run-hooks inferior-buffer)
+          (setf (buffer-local-value 'julia-repl--inferior-buffer-suffix inferior-buffer) suffix)
+          inferior-buffer)))))
 
 ;;;###autoload
 (defun julia-repl ()
@@ -505,16 +497,8 @@ A closing newline is sent according to NO-NEWLINE:
 Unless NO-BRACKETED-PASTE, bracketed paste control sequences are used."
   (let ((inferior-buffer (julia-repl-inferior-buffer)))
     (display-buffer inferior-buffer)
-    (with-current-buffer inferior-buffer
-      (unless no-bracketed-paste        ; bracketed paste start
-        (term-send-raw-string "\e[200~"))
-      (term-send-raw-string (string-trim string))
-      (when (eq no-newline 'prefix)
-        (setq no-newline current-prefix-arg))
-      (unless no-newline
-        (term-send-raw-string "\^M"))
-      (unless no-bracketed-paste        ; bracketed paste stop
-        (term-send-raw-string "\e[201~")))))
+    (julia-repl--send-to-backend julia-repl-terminal-backend
+                                 inferior-buffer string (not no-newline) (not no-bracketed-paste))))
 
 (defun julia-repl-send-line ()
   "Send the current line to the Julia REPL term buffer.

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -495,7 +495,7 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
 
 (cl-defun julia-repl-inferior-buffer (&key (executable-key (julia-repl--get-executable-key))
                                            (suffix julia-repl-inferior-buffer-name-suffix)
-                                           (terminal-backend julia-repl-terminal-backend ))
+                                           (terminal-backend julia-repl--terminal-backend ))
   "Return the Julia REPL inferior buffer, creating one if it does not exist."
   (let* ((name (julia-repl--inferior-buffer-name executable-key suffix))
          (live-buffer (julia-repl--locate-live-buffer terminal-backend name)))

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -190,8 +190,8 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
            (with-current-buffer inferior-buffer
              (assert (eq major-mode 'vterm-mode) t "Expected vterm-mode. Changed mode or backends?")
              ;; cf https://github.com/akermu/emacs-libvterm/issues/270
-             (when (and vterm--process
-                        (memq (process-status vterm--process) '(run stop open listen connect)))
+             (when (let ((proc (buffer-local-value 'vterm--process inferior-buffer)))
+                     (and proc (memq (process-status proc) '(run stop open listen connect))))
                inferior-buffer))))
 
      (cl-defmethod julia-repl--make-buffer ((_terminal-backend julia-repl--buffer-vterm)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -103,6 +103,11 @@ in your Emacs init file after loading this package."
   :type 'string
   :group 'julia-repl)
 
+(defcustom julia-repl-set-term-escape t
+  "Set the escape char C-x globally for term. Useful for switching windows, but users who do not want this globally should set it to nil."
+  :type 'boolean
+  :group 'julia-repl)
+
 ;;;; utility functions
 
 (defun julia-repl--add-earmuffs (buffer-name)
@@ -149,7 +154,8 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
               (define-key term-raw-map k (global-key-binding k)))
             julia-repl-captures)
       (term-char-mode)
-      (term-set-escape-char ?\C-x)      ; useful for switching windows
+      (when julia-repl-set-term-escape
+        (term-set-escape-char ?\C-x))      ; useful for switching windows
       (setq-local term-prompt-regexp "^(julia|shell|help\\?|(\\d+\\|debug ))>")
       (setq-local term-suppress-hard-newline t)  ; reflow text
       (setq-local term-scroll-show-maximum-output t)


### PR DESCRIPTION
Factor out code interacting with the terminal using generic functions.

Add backend code for [emacs-libvterm](https://github.com/akermu/emacs-libvterm).

Disables byte compilation do get conditional code to work.