### PR TITLE
Don't use Unicode when querying basedir, document preference for UTF8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Place this in your **Emacs initialization files** (eg `.emacs`):
 ```
 If you want to use a Julia executable other than `julia` in your path, see [below](#julia-executables).
 
+If you are experiencing problems with [Unicode characters](https://docs.julialang.org/en/v1/manual/unicode-input/) in the Julia REPL, try setting the relevant coding/language environment, eg
+```emacs-lisp
+(set-language-environment "UTF-8")
+```
+
 ## Usage
 
 `M-x julia-repl`, or `C-c C-z` from a buffer in which the `julia-repl` minor mode is active starts a new inferior Julia process. The keys below can be used to interact with this process.

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -205,7 +205,7 @@ This matches the buffer name created by ‘make-term’."
 When NIL, this was unsuccessful."
   (let* ((prefix "OK") ; prefix is used to verify that there was no error and help with extraction
          (expr (concat "print(\"" prefix
-                       "\" * normpath(joinpath(VERSION ≤ v\"0.7-\" ? JULIA_HOME : Sys.BINDIR, "
+                       "\" * normpath(joinpath(VERSION <= v\"0.7-\" ? JULIA_HOME : Sys.BINDIR, "
                        "Base.DATAROOTDIR, \"julia\", \"base\")))"))
          (switches " --history-file=no --startup-file=no -qe ")
          (maybe-basedir (shell-command-to-string


### PR DESCRIPTION
Fixes #90.