### PR TITLE
In default entry point, changed switch-to-buffer-other-window to pop-to-buffer

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -451,7 +451,7 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
 
 This is the standard entry point for using this package."
   (interactive)
-  (switch-to-buffer-other-window (julia-repl-inferior-buffer)))
+  (pop-to-buffer (julia-repl-inferior-buffer)))
 
 ;;
 ;; path rewrites


### PR DESCRIPTION
To address #98 and allow the user to control screen splitting, I changed `switch-to-buffer-other-window` to `pop-to-buffer` at the default entry point, as suggested [here](https://emacs.stackexchange.com/a/61445/30563).