### PR TITLE
Configure JULIA_EDITOR on the julia side

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,15 @@ See the help of `term` for more.
 
 The `@edit` macro can be called with `C-c C-e` when the `julia-repl-mode` minor mode is enabled. The behavior depends on the value of the `JULIA_EDITOR` envoronment variable in the Julia session. The command `julia-repl-set-julia-editor` is provided to conveniently control this from emacs.
 
-To use "emacsclient" as a default in each Julia REPL, call `julia-repl-use-emacsclient`:
+To use "emacsclient" as a default in each Julia REPL you open in emacs, add the following code to your `~/.julia/config/startup.jl`:
+
+```julia
+if haskey(ENV, "INSIDE_EMACS")
+    ENV["JULIA_EDITOR"] = "emacsclient"
+end
+```
+
+If you cannot edit your `startup.jl`, you can configure the editor in each repl after starting it with:
 
 ```elisp
 (add-hook 'julia-repl-hook #'julia-repl-use-emacsclient)


### PR DESCRIPTION
Configuring JULIA_EDITOR in your `startup.jl` avoids interactions with OhMyREPL that can produce invalid syntax due to autocompletion if you send Julia code in a hook early before the REPL is fully initialized.