### PR TITLE
Include a list of keyboard shortcuts in help text

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -774,7 +774,9 @@ When called with a prefix argument, activate the home project."
 
 ;;;###autoload
 (define-minor-mode julia-repl-mode
-  "Minor mode for interacting with a Julia REPL running inside a term."
+  "Minor mode for interacting with a Julia REPL running inside a term.
+
+\\{julia-repl-mode-map}"
   nil ">"
   `((,(kbd "C-c C-a")    . julia-repl-activate-parent)
     (,(kbd "C-c C-b")    . julia-repl-send-buffer)


### PR DESCRIPTION
This makes it easier for people to discover the keyboard shortcuts
supported by julia-repl-mode. With this change, the help of
julia-repl-mode (C-h f) as well as the list of activate modes (C-h m)
shows the following list:

    key             binding
    ---             -------

    C-c             Prefix Command
    <C-return>      julia-repl-send-line

    C-c C-a         julia-repl-activate-parent
    C-c C-b         julia-repl-send-buffer
    C-c C-c         julia-repl-send-region-or-line
    C-c C-d         julia-repl-doc
    C-c C-e         julia-repl-edit
    C-c C-l         julia-repl-list-methods
    C-c RET         julia-repl-macroexpand
    C-c C-p         julia-repl-cd
    C-c C-s         julia-repl-prompt-set-inferior-buffer-name-suffix
    C-c C-t         julia-repl-includet-buffer
    C-c C-v         julia-repl-prompt-set-executable-key
    C-c C-z         julia-repl