### PR TITLE
Make "C-c C-z" switch back and forth between the script and REPL buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you are experiencing problems with [Unicode characters](https://docs.julialan
 | `C-c C-s`     | prompt for buffer name suffix                               |
 | `C-c C-t`     | send whole buffer to REPL (using Revise.includet)           |
 | `C-c C-v`     | prompt for Julia executable                                 |
-| `C-c C-z`     | raise the REPL or create a new one (or switch back)         |
+| `C-c C-z`     | raise the REPL or create a new one (or switch back from REPL – only in `vterm` backend) |
 | `C-RET`       | send line to REPL (without bracketed paste)                 |
 
 All actions that send something to the REPL terminate with a **newline**, triggering evaluation. If you want to avoid sending a newline (eg maybe because you want to edit an expression), use prefix arguments (`C--` or `C-u`, currently both have the same effect). This of course does not apply to `C-c C-b`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you are experiencing problems with [Unicode characters](https://docs.julialan
 | `C-c C-s`     | prompt for buffer name suffix                               |
 | `C-c C-t`     | send whole buffer to REPL (using Revise.includet)           |
 | `C-c C-v`     | prompt for Julia executable                                 |
-| `C-c C-z`     | raise the REPL or create a new one                          |
+| `C-c C-z`     | raise the REPL or create a new one (or switch back)         |
 | `C-RET`       | send line to REPL (without bracketed paste)                 |
 
 All actions that send something to the REPL terminate with a **newline**, triggering evaluation. If you want to avoid sending a newline (eg maybe because you want to edit an expression), use prefix arguments (`C--` or `C-u`, currently both have the same effect). This of course does not apply to `C-c C-b`.

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -305,6 +305,9 @@ used to generate a buffer name.")
 These are used for offering choices when selecting new suffix.
 For internal use only.")
 
+(defvar-local julia-repl--script-buffer nil
+  "Buffer active before calling `julia-repl'.")
+
 (defvar julia-repl-executable-key nil
   "Key for the executable associated with the buffer.
 
@@ -533,6 +536,8 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
                (inferior-buffer (julia-repl--make-buffer terminal-backend name executable-path
                                                          (when switches
                                                            (split-string switches)))))
+	  (with-current-buffer inferior-buffer
+	    (local-set-key (kbd "C-c C-z") #'julia-repl--switch-back))
           (when julia-repl-compilation-mode
             (julia-repl--setup-compilation-mode inferior-buffer basedir))
           (julia-repl--run-hooks inferior-buffer)
@@ -545,7 +550,17 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
 
 This is the standard entry point for using this package."
   (interactive)
-  (pop-to-buffer (julia-repl-inferior-buffer)))
+  (let ((script-buffer (current-buffer))
+	(inferior-buffer (julia-repl-inferior-buffer)))
+    (with-current-buffer inferior-buffer
+      (setq julia-repl--script-buffer script-buffer))
+    (pop-to-buffer inferior-buffer)))
+
+(defun julia-repl--switch-back ()
+  "Switch to the buffer that was active before last call to `julia-repl'."
+  (interactive)
+  (when (buffer-live-p julia-repl--script-buffer)
+    (switch-to-buffer-other-window julia-repl--script-buffer)))
 
 ;;
 ;; path rewrites

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -213,6 +213,7 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
       (with-current-buffer vterm-buffer
         (let ((vterm-shell (s-join " " (cons executable-path switches))))
           (vterm-mode)
+          (local-set-key (kbd "C-c C-z") #'julia-repl--switch-back)
           ;; NOTE workaround for https://github.com/akermu/emacs-libvterm/issues/316, remove when fixed
           (add-hook 'compilation-shell-minor-mode-hook
                     ;; NOTE run *after* vterm's hook and overwrite `next-error-function'
@@ -536,8 +537,6 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
                (inferior-buffer (julia-repl--make-buffer terminal-backend name executable-path
                                                          (when switches
                                                            (split-string switches)))))
-	  (with-current-buffer inferior-buffer
-	    (local-set-key (kbd "C-c C-z") #'julia-repl--switch-back))
           (when julia-repl-compilation-mode
             (julia-repl--setup-compilation-mode inferior-buffer basedir))
           (julia-repl--run-hooks inferior-buffer)


### PR DESCRIPTION
[julia-vterm.el](https://github.com/shg/julia-vterm.el) implements this and I miss it in julia-repl.