### PR TITLE
Add integration with EmacsVterm.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Support for the vterm backend is WIP. In the long run it is hoped that it will r
 
 3. You may want to `(setq vterm-kill-buffer-on-exit nil)` to prevent the buffers associated with terminated Julia processes being killed automatically. This allows you to retain output and see error messages if the process does not start.
 
+4. You can also install [EmacsVterm.jl](https://github.com/wentasah/EmacsVterm.jl) package, which improves integration between Julia REPL and Emacs.
+
 ## Using the @edit macro
 
 The `@edit` macro can be called with `C-c C-e` when the `julia-repl-mode` minor mode is enabled. The behavior depends on the value of the `JULIA_EDITOR` envoronment variable in the Julia session. The command `julia-repl-set-julia-editor` is provided to conveniently control this from emacs.

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -811,6 +811,16 @@ be added."
        (shr-render-region (point-min) (point-max))
        (goto-char (point-min))
        (view-mode-enter)))
+    (`("image" . ,_)
+     (with-current-buffer-window "*julia-img*" nil nil
+       (let ((imgdata (base64-decode-string base64data)))
+         ;; TODO: Implement different display modes like julia-snail
+         ;; allow images to be erased
+         (fundamental-mode)
+         (read-only-mode -1)
+         (erase-buffer)
+         (insert imgdata)
+         (image-mode))))
     (_ (error "Unsupported data kind `%s' or MIME type `%s' (upgrade julia-repl or use older EmacsVterm.jl)"
               kind mime))))
 

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -805,7 +805,7 @@ Called by EmacsVterm.jl to show HTML documentation."
        (shr-render-region (point-min) (point-max))
        (goto-char (point-min))
        (view-mode-enter)))
-    (t (error "Unsupported MIME type"))))
+    (_ (error "Unsupported MIME type"))))
 
 ;;;###autoload
 (define-minor-mode julia-repl-mode

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -270,7 +270,6 @@ Valid backends are currently:
      (setq julia-repl--terminal-backend (make-julia-repl--buffer-ansi-term)))
     ('vterm
      (require 'vterm)
-     (require 'eww)
      (setq julia-repl--terminal-backend (make-julia-repl--buffer-vterm))
      (add-to-list 'vterm-eval-cmds '("julia-repl--show" julia-repl--show)))
     (otherwise
@@ -801,17 +800,11 @@ When called with a prefix argument, activate the home project."
 Called by EmacsVterm.jl to show HTML documentation."
   (pcase mime
     ("text/html"
-     (let ((data (decode-coding-string (base64-decode-string base64data) 'utf-8))
-           (doc-buffer (get-buffer-create "*julia-doc*")))
-       (with-current-buffer doc-buffer
-         (eww-setup-buffer))
-       (with-temp-buffer
-         (insert "Content-type: text/html\n")
-         (insert (format "Content-length: %d\n" (length data)))
-         (insert "\n")
-         (insert data)
-         (eww-render 200 "julia://doc" nil doc-buffer))
-       (display-buffer doc-buffer)))
+     (with-current-buffer-window "*julia-doc*" nil nil
+       (insert (decode-coding-string (base64-decode-string base64data) 'utf-8))
+       (shr-render-region (point-min) (point-max))
+       (goto-char (point-min))
+       (view-mode-enter)))
     (t (error "Unsupported MIME type"))))
 
 ;;;###autoload


### PR DESCRIPTION
See https://github.com/wentasah/EmacsVterm.jl.

Specifically, this allows to show Julia documentation (`@doc ...` invocation or `C-c C-d` in julia-mode buffers) in a separate Emacs buffer via EWW.

This is my initial attempt at implementing this and it would be great to receive some feedback. It works by sending Markdown documents from Julia REPL (converted to HTML) via vterm escape sequences to Emacs. Emacs then shows this document in `*julia-doc*` EWW buffer. 

I'm not sure this is the best way to implement it. The drawback is that all Markdown documents are shown in a separate buffer, not only the documentation (try executing `md"Hello"`). Currently, it's not a problem for my use cases, but I can imagine it being annoying when working with non-documentation Markdown data.

An alternative way of implementing this would be that EmacsVterm.jl informs Emacs in `__init__` about it being active and then `julia-repl` would not send `@doc` to show the documentation but some EmacsVterm-specific function (e.g. `EmacsVterm.doc`).

If somebody has an opinion about this, I'd be happy to hear it.