### PR TITLE
github: CI: Add Emacs 28.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
           - 26.3
           - 27.1
           - 27.2
+          - 28.1
         ignore_warnings:
           - true
         include:


### PR DESCRIPTION
Add Emacs 28.1 to the list of Emacs versions we test against.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>