### PR TITLE
Make julia-repl--capture-basedir compatible with Windows

### DIFF
--- a/julia-repl.el
+++ b/julia-repl.el
@@ -368,9 +368,8 @@ When NIL, this was unsuccessful."
          (expr (concat "print(\"" prefix
                        "\" * normpath(joinpath(VERSION <= v\"0.7-\" ? JULIA_HOME : Sys.BINDIR, "
                        "Base.DATAROOTDIR, \"julia\", \"base\")))"))
-         (switches " --history-file=no --startup-file=no -qe ")
-         (maybe-basedir (shell-command-to-string
-                         (concat executable-path switches (concat "'" expr "'")))))
+	 (lines (process-lines executable-path "--history-file=no" "--startup-file=no" "-qe" expr))
+	 (maybe-basedir (car lines)))
     (when (string-prefix-p prefix maybe-basedir)
       (substring maybe-basedir (length prefix)))))
 


### PR DESCRIPTION
Previously, we used `shell-command-to-string` to run Julia with some arguments. The whole command string was formatted as a command for UNIX shell assuming its quoting rules. This didn't work when the command was executed by Windows' `cmd.exe`.

Now, we use `process-lines` instead, which allows specifying individual arguments separately, without assuming UNIX shell and its quoting.

This fixes #128, however there are other problems that prevent `julia-repl` to work on Windows :-(.