### PR TITLE
Added support for command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ If you cannot edit your `startup.jl`, you can configure the editor in each repl 
 ```elisp
 (add-hook 'julia-repl-hook #'julia-repl-use-emacsclient)
 ```
+## Passing command line arguments, i.e. `push!` to `ARGS`
+
+If you need to pass some command line arguments, you can raise the REPL with `C-u C-c C-z` and you will be promted to write you command line arguments. They will be sent to the REPL in a `push!(ARGS,[...])` call.
+
+This is equivalent of running in the terminal
+
+```
+$ julia -i <my_scrip>.jl arg1 args2 ...
+```
 
 ## More colors
 

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -899,6 +899,23 @@ When called with a prefix argument, activate the home project."
                    (expand-file-name (file-name-directory projectfile)) "\")")))
       (message "could not find project file"))))
 
+
+(defun julia-repl--push-args (args)
+  (s-prepend
+   (s-prepend "push!(ARGS,\""
+	      (s-join"\",\"" (s-split " " args t))) "\")" ))
+
+
+(defun julia-repl-with-args (args)
+  (interactive "s")
+  (julia-repl--send-string (julia-repl--push-args args)))
+
+(defun julia-repl-activate-parent-with-args (arg args)
+  (interactive "P\ns")
+  (julia-repl-activate-parent arg)
+  (julia-repl-with-args args))
+
+
 (defun julia-repl-set-julia-editor (editor)
   "Set the JULIA_EDITOR environment variable."
   (interactive)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -643,18 +643,22 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
           inferior-buffer)))))
 
 ;;;###autoload
-(defun julia-repl ()
+(defun julia-repl (args)
   "Raise the Julia REPL inferior buffer, creating one if it does not exist.
 
 This is the standard entry point for using this package."
-  (interactive)
+  (interactive "P")
   (let ((script-buffer (current-buffer))
 	(inferior-buffer (julia-repl-inferior-buffer)))
     (with-current-buffer inferior-buffer
       (setq julia-repl--script-buffer script-buffer))
     (if julia-repl-pop-to-buffer
 	(pop-to-buffer inferior-buffer)
-      (switch-to-buffer inferior-buffer))))
+      (switch-to-buffer inferior-buffer)))
+  (if args
+      (julia-repl--send-string
+       (julia-repl--push-args
+	(read-from-minibuffer "Command line args: ")))))
 
 (defun julia-repl--switch-back ()
   "Switch to the buffer that was active before last call to `julia-repl'."

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -910,17 +910,10 @@ When called with a prefix argument, activate the home project."
 	      (s-join"\",\"" (s-split " " args t))) "\")" ))
 
 
-(defun julia-repl-with-args ()
-  (interactive)
+(defun julia-repl--ask-for-args ()
   (let ((str (read-from-minibuffer "Command line args: ")))
     (if (s-present? str)
 	(julia-repl--send-string (julia-repl--push-args str)))))
-
-(defun julia-repl-activate-parent-with-args (arg)
-  (interactive "P\ns")
-  (julia-repl-activate-parent arg)
-  (julia-repl-with-args args))
-
 
 (defun julia-repl-set-julia-editor (editor)
   "Set the JULIA_EDITOR environment variable."

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -642,6 +642,16 @@ Valid keys are the first items in ‘julia-repl-executable-records’."
             (setq-local julia-repl--inferior-buffer-suffix suffix))
           inferior-buffer)))))
 
+(defun julia-repl--push-args (args)
+  (s-prepend
+   (s-prepend "push!(ARGS,\""
+	      (s-join"\",\"" (s-split " " args t))) "\")" ))
+
+(defun julia-repl--ask-for-args ()
+  (let ((str (read-from-minibuffer "Command line args: ")))
+    (if (s-present? str)
+	(julia-repl--send-string (julia-repl--push-args str)))))
+
 ;;;###autoload
 (defun julia-repl (args)
   "Raise the Julia REPL inferior buffer, creating one if it does not exist.
@@ -655,10 +665,7 @@ This is the standard entry point for using this package."
     (if julia-repl-pop-to-buffer
 	(pop-to-buffer inferior-buffer)
       (switch-to-buffer inferior-buffer)))
-  (if args
-      (julia-repl--send-string
-       (julia-repl--push-args
-	(read-from-minibuffer "Command line args: ")))))
+  (if args (julia-repl--ask-for-args)))
 
 (defun julia-repl--switch-back ()
   "Switch to the buffer that was active before last call to `julia-repl'."
@@ -902,18 +909,6 @@ When called with a prefix argument, activate the home project."
            (concat "import Pkg; Pkg.activate(\""
                    (expand-file-name (file-name-directory projectfile)) "\")")))
       (message "could not find project file"))))
-
-
-(defun julia-repl--push-args (args)
-  (s-prepend
-   (s-prepend "push!(ARGS,\""
-	      (s-join"\",\"" (s-split " " args t))) "\")" ))
-
-
-(defun julia-repl--ask-for-args ()
-  (let ((str (read-from-minibuffer "Command line args: ")))
-    (if (s-present? str)
-	(julia-repl--send-string (julia-repl--push-args str)))))
 
 (defun julia-repl-set-julia-editor (editor)
   "Set the JULIA_EDITOR environment variable."

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -910,11 +910,13 @@ When called with a prefix argument, activate the home project."
 	      (s-join"\",\"" (s-split " " args t))) "\")" ))
 
 
-(defun julia-repl-with-args (args)
-  (interactive "s")
-  (julia-repl--send-string (julia-repl--push-args args)))
+(defun julia-repl-with-args ()
+  (interactive)
+  (let ((str (read-from-minibuffer "Command line args: ")))
+    (if (s-present? str)
+	(julia-repl--send-string (julia-repl--push-args str)))))
 
-(defun julia-repl-activate-parent-with-args (arg args)
+(defun julia-repl-activate-parent-with-args (arg)
   (interactive "P\ns")
   (julia-repl-activate-parent arg)
   (julia-repl-with-args args))


### PR DESCRIPTION
Added support for command line arguments.

- added `julia-repl--push-args` : It prepares the argument to be pushed to `ARGS` 
- added `julia-repl--ask-for-args`: it raises the minibuffer asking for command line arguments, the send them to repl 
- changed `julia-repl`: now it is a `(interactive "P")` functions. if  prefixed, it asks for command line arguments (=> `C-u C-c C-z` asks for command line arguments, `C-c C-z` works as before)

resolves #153 