### PR TITLE
Add `ghostel` backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ then the next time you open a REPL, it will have the name `*julia-master-tests*`
 
 The default is `ansi-term`, which is included in Emacs, but it is recommended that you use [`vterm` via `emacs-libvterm`](https://github.com/akermu/emacs-libvterm) (it is not the default since you need to install an extra package and the binary).
 
-You can also use [`eat`](https://codeberg.org/akib/emacs-eat/) as a backend.
+You can also use [`eat`](https://codeberg.org/akib/emacs-eat/) or [`ghostel`](https://github.com/dakra/ghostel) as a backend.
 
 **Note to Windows users**: you may not be able to use `eat` and/or `vterm` directly from native Windows Emacs, but there have been reports of people using them successfully from WSL (Windows Subsistem for Linux) 2. Please understand that supporting those terminal emulators is outside the scope of this package; `julia-repl` merely provides bindings for them conditional on availability on your system.
 
@@ -149,6 +149,10 @@ See the help of `term` for more.
 #### Using `eat`
 
 Install [`eat`](https://codeberg.org/akib/emacs-eat/) and use `(julia-repl-set-terminal-backend 'eat)` in your config file.
+
+#### Using `ghostel`
+
+Install [`ghostel`](https://github.com/dakra/ghostel) and use `(julia-repl-set-terminal-backend 'ghostel)` in your config file.
 
 ## Using the @edit macro
 

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -268,6 +268,48 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
       (when ret-p
 	(eat-term-send-string eat-terminal "\^M")))))
 
+
+;;; ghostel term
+
+(with-eval-after-load 'ghostel
+
+  (defvar ghostel--process)
+  (defvar ghostel-use-native-pty)
+
+  (cl-defstruct julia-repl--buffer-ghostel
+    "Terminal backend using ‘ghostel’, which needs to be installed and loaded.")
+
+  (cl-defmethod julia-repl--locate-live-buffer ((_terminal-backend julia-repl--buffer-ghostel)
+						name)
+    (if-let ((inferior-buffer (get-buffer (julia-repl--add-earmuffs name))))
+	(with-current-buffer inferior-buffer
+	  (cl-assert (eq major-mode 'ghostel-mode) nil "Expected ghostel-mode. Changed mode or backends?")
+	  (when (process-live-p ghostel--process)
+	    inferior-buffer))))
+
+  (cl-defmethod julia-repl--make-buffer ((_terminal-backend julia-repl--buffer-ghostel)
+					 name executable-path switches)
+    (let ((inferior-buffer (get-buffer-create (julia-repl--add-earmuffs name))))
+      (with-current-buffer inferior-buffer
+	(setq-local ghostel-buffer-name-function nil)
+	(let ((ghostel-use-native-pty nil))
+	  (ghostel-exec inferior-buffer executable-path switches))
+	(mapc (lambda (k)
+		(define-key ghostel-semi-char-mode-map k (global-key-binding k)))
+	      julia-repl-captures)
+	(local-set-key (kbd "C-c C-z") #'julia-repl--switch-back))
+      inferior-buffer))
+
+  (cl-defmethod julia-repl--send-to-backend ((_terminal-backend julia-repl--buffer-ghostel)
+					     buffer string paste-p ret-p)
+    (with-current-buffer buffer
+      (if paste-p
+	  (ghostel-paste-string string)
+        (ghostel-send-string string))
+      (when ret-p
+	(ghostel-send-key "return")))))
+
+
 ;;; compiler output regexps for navigation
 
 (defconst julia-repl--CR-path
@@ -330,7 +372,9 @@ Valid backends are currently:
 
 - ‘vterm’, which requires that vterm is installed. See URL ‘https://github.com/akermu/emacs-libvterm’.
 
-- ‘eat’, which requires that eat is installed. See URL ‘https://codeberg.org/akib/emacs-eat’."
+- ‘eat’, which requires that eat is installed. See URL ‘https://codeberg.org/akib/emacs-eat’.
+
+- ‘ghostel’, which requires that ghostel is installed. See URL ‘https://github.com/dakra/ghostel’."
   (interactive "S")
   (cl-case backend
     (ansi-term
@@ -342,6 +386,9 @@ Valid backends are currently:
     (eat
      (require 'eat)
      (setq julia-repl--terminal-backend (make-julia-repl--buffer-eat)))
+    (ghostel
+     (require 'ghostel)
+     (setq julia-repl--terminal-backend (make-julia-repl--buffer-ghostel)))
     (otherwise
      (error "Unrecognized backend “%s”." backend))))
 

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -274,7 +274,6 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 (with-eval-after-load 'ghostel
 
   (defvar ghostel--process)
-  (defvar ghostel--managed-buffer-name)
   (defvar ghostel-use-native-pty)
   (defvar ghostel-buffer-name-function)
 
@@ -298,10 +297,10 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 					 name executable-path switches)
     (let ((inferior-buffer (get-buffer-create (julia-repl--add-earmuffs name))))
       (with-current-buffer inferior-buffer
-	(let ((ghostel-use-native-pty nil))
+	(let ((ghostel-use-native-pty nil)
+	      (ghostel-buffer-name-function nil))
 	  (ghostel-exec inferior-buffer executable-path switches))
 	(setq-local ghostel-buffer-name-function nil)
-	(setq-local ghostel--managed-buffer-name (buffer-name))
 	(mapc (lambda (k)
 		(define-key ghostel-semi-char-mode-map k (global-key-binding k)))
 	      julia-repl-captures)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -274,7 +274,9 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 (with-eval-after-load 'ghostel
 
   (defvar ghostel--process)
+  (defvar ghostel--managed-buffer-name)
   (defvar ghostel-use-native-pty)
+  (defvar ghostel-buffer-name-function)
 
   (cl-defstruct julia-repl--buffer-ghostel
     "Terminal backend using ‘ghostel’, which needs to be installed and loaded.")
@@ -291,9 +293,10 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 					 name executable-path switches)
     (let ((inferior-buffer (get-buffer-create (julia-repl--add-earmuffs name))))
       (with-current-buffer inferior-buffer
-	(setq-local ghostel-buffer-name-function nil)
 	(let ((ghostel-use-native-pty nil))
 	  (ghostel-exec inferior-buffer executable-path switches))
+	(setq-local ghostel-buffer-name-function nil)
+	(setq-local ghostel--managed-buffer-name (buffer-name))
 	(mapc (lambda (k)
 		(define-key ghostel-semi-char-mode-map k (global-key-binding k)))
 	      julia-repl-captures)

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -281,6 +281,11 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
   (cl-defstruct julia-repl--buffer-ghostel
     "Terminal backend using ‘ghostel’, which needs to be installed and loaded.")
 
+  (defun julia-repl--ghostel-scroll-to-bottom ()
+    "Scroll visible windows displaying the current ghostel buffer to the bottom."
+    (dolist (window (get-buffer-window-list (current-buffer) nil t))
+      (ghostel--anchor-window window)))
+
   (cl-defmethod julia-repl--locate-live-buffer ((_terminal-backend julia-repl--buffer-ghostel)
 						name)
     (if-let ((inferior-buffer (get-buffer (julia-repl--add-earmuffs name))))
@@ -306,6 +311,7 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
   (cl-defmethod julia-repl--send-to-backend ((_terminal-backend julia-repl--buffer-ghostel)
 					     buffer string paste-p ret-p)
     (with-current-buffer buffer
+      (julia-repl--ghostel-scroll-to-bottom)
       (if paste-p
 	  (ghostel-paste-string string)
         (ghostel-send-string string))

--- a/julia-repl.el
+++ b/julia-repl.el
@@ -273,6 +273,7 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
 
 (with-eval-after-load 'ghostel
 
+  ;; this variables are defined by ghostel.el and are only locally changed.
   (defvar ghostel--process)
   (defvar ghostel-use-native-pty)
   (defvar ghostel-buffer-name-function)
@@ -290,15 +291,15 @@ When PASTE-P, “bracketed paste” mode will be used. When RET-P, terminate wit
     (if-let ((inferior-buffer (get-buffer (julia-repl--add-earmuffs name))))
 	(with-current-buffer inferior-buffer
 	  (cl-assert (eq major-mode 'ghostel-mode) nil "Expected ghostel-mode. Changed mode or backends?")
-	  (when (process-live-p ghostel--process)
+	  (when (process-live-p ghostel--process) ; check if Julia sessions is still live
 	    inferior-buffer))))
 
   (cl-defmethod julia-repl--make-buffer ((_terminal-backend julia-repl--buffer-ghostel)
 					 name executable-path switches)
     (let ((inferior-buffer (get-buffer-create (julia-repl--add-earmuffs name))))
       (with-current-buffer inferior-buffer
-	(let ((ghostel-use-native-pty nil)
-	      (ghostel-buffer-name-function nil))
+	(let ((ghostel-use-native-pty nil)	  ; use Emacs process machinery
+	      (ghostel-buffer-name-function nil)) ; avoid ghostel's renaming
 	  (ghostel-exec inferior-buffer executable-path switches))
 	(setq-local ghostel-buffer-name-function nil)
 	(mapc (lambda (k)


### PR DESCRIPTION
Adding support for [`ghostel`](https://github.com/dakra/ghostel) terminal backend, adressing https://github.com/tpapp/julia-repl/issues/161.

It is working fine on my machine; it is behaving like `vterm`. 
I'm not an Elisp expert, so probably the implementation could be more elegant.